### PR TITLE
iteritems() -> items() for quick Python3 fix

### DIFF
--- a/templates/dellos10_logging.j2
+++ b/templates/dellos10_logging.j2
@@ -18,7 +18,7 @@ dellos_logging:
 
 ###############################################}
 {% if dellos_logging is defined and dellos_logging %}
-  {% for key,value in dellos_logging.iteritems() %}
+  {% for key,value in dellos_logging.items() %}
     {% if key == "logging" %}
       {% for item in value %}
         {% if item.ip is defined and item.ip %}

--- a/templates/dellos6_logging.j2
+++ b/templates/dellos6_logging.j2
@@ -12,7 +12,7 @@ dellos_logging:
 #####################################}
 {% if dellos_logging is defined and dellos_logging %}
 
-{% for key,value in dellos_logging.iteritems() %}
+{% for key,value in dellos_logging.items() %}
   {% if key == "logging" %}
     {% for item in value %}
       {% if item.ip is defined and item.ip %}

--- a/templates/dellos9_logging.j2
+++ b/templates/dellos9_logging.j2
@@ -47,7 +47,7 @@ dellos_logging:
  
 ###################################################}
 {% if dellos_logging is defined and dellos_logging %}
-{% for key,value in dellos_logging.iteritems() %}
+{% for key,value in dellos_logging.items() %}
   {% if key == "buffer" %}
     {% if value %}
 logging buffered {{ value }}


### PR DESCRIPTION
possible performance hit for large vars files
on Python2 but unlikely to impact most configs